### PR TITLE
Cloud Formation Update

### DIFF
--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -549,12 +549,6 @@ Outputs:
   RSCHost:
     Description: RStudio Connect UI
     Value: !Join [ "", ["http://", !GetAtt RSCInstance.PublicIp]]
-  RSCDefaultUser:
-    Description: RStudio Connect default user
-    Value: admin
-  RSCDefaultPassword:
-    Description: RStudio Connect initial default user password
-    Value: !Ref RSCInstance
   RSPMHost:
     Description: RStudio Package Manager UI
     Value: !Join [ "", ["http://", !GetAtt RSPMInstance.PublicIp]]

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -332,7 +332,13 @@ Resources:
             systemctl enable rstudio-launcher
             systemctl restart rstudio-server
             systemctl restart rstudio-launcher
-
+            
+            # Create first user
+            user_passwd=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+            sudo useradd -p $(openssl passwd -crypt $user_passwd) rstudio-user
+            unset user_passwd
+            
+            # Download Wait for It
             curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
             chmod +x /usr/local/bin/wait-for-it.sh
 

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -196,7 +196,7 @@ Mappings:
     eu-west-3:
       AMI: ami-0790eaebd8188279e
     us-east-1:
-      AMI: ami-0893c8bcf961b37fc
+      AMI: ami-04bd6989dfa69be83
     us-east-2:
       AMI: ami-0a0fcfe7249fac9f5
     us-west-1:
@@ -212,13 +212,13 @@ Mappings:
     eu-west-1:
       AMI: ami-0e958dba717422144
     eu-west-2:
-      AMI: ami-0e0633ab0869ee960
+      AMI: ami-00d7054d3d517802c
     eu-west-3:
       AMI: ami-0355e9150a06de678
     us-east-1:
-      AMI: ami-01b2d1ebce4dba914
+      AMI: ami-0925289e48c7e041c
     us-east-2:
-      AMI: ami-09103663a28d3b6ce
+      AMI: ami-0d654bde0b1fb03ae
     us-west-1:
       AMI: ami-04ed4e5e4ce91002c
     us-west-2:
@@ -246,7 +246,7 @@ Mappings:
     eu-west-3:
       AMI: ami-07f15e5d10f19f45c
     us-east-1:
-      AMI: ami-0b67497386d94876f
+      AMI: ami-05bcd1624763edb6d
     us-east-2:
       AMI: ami-077706d681ccd250b
     us-west-1:

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -236,33 +236,33 @@ Mappings:
 
   RSPMRegionMap:
     eu-central-1:
-      AMI: ami-01aa8c68198f50949
+      AMI: ami-078161336b35798d2
     eu-north-1:
-      AMI: ami-0f91b8833026dc677
+      AMI: ami-067225336df869b84
     eu-west-1:
-      AMI: ami-0a35783d62a694f07
+      AMI: ami-06f89ac71be16f3c0
     eu-west-2:
-      AMI: ami-04f3891b57f72d156
+      AMI: ami-0f55fbbb61e294004
     eu-west-3:
-      AMI: ami-07f15e5d10f19f45c
+      AMI: ami-04beed3dc1066d79b
     us-east-1:
       AMI: ami-05bcd1624763edb6d
     us-east-2:
-      AMI: ami-077706d681ccd250b
+      AMI: ami-0b56f184c0b9c081a
     us-west-1:
-      AMI: ami-0ea37668564fd9ada
+      AMI: ami-078e22c833d1b41e9
     us-west-2:
-      AMI: ami-0dc8151e53de2a56f
+      AMI: ami-031669f9b2ac511ae
     ap-northeast-1:
-      AMI: ami-01b24d36b8500b4a4
+      AMI: ami-0c34049f10b9d1728
     ap-northeast-2:
-      AMI: ami-008bd0a5a27463e9d
+      AMI: ami-01425492ce409f256
     ap-south-1:
-      AMI: ami-0a3d254c2a454ebc8
+      AMI: ami-0536674dff3cd3bc0
     ap-southeast-1:
-      AMI: ami-0c184ad733fa9eb42
+      AMI: ami-0000c47a0cdfc3180
     ap-southeast-2:
-      AMI: ami-0d9fdec2761824f47
+      AMI: ami-06f37890301137a87
 
 Resources:
   RSPInstance:

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -305,6 +305,13 @@ Resources:
             REPOS_CONFIG_FILE=/etc/rstudio/repos.conf
             sed -i -e "s|#CRAN=RSPM_SERVER_ADDRESS|CRAN=http://${RSPM_IP}/cran/__linux__/bionic/latest|" $REPOS_CONFIG_FILE
 
+            PIP_CONFIG_FILE=/etc/pip.conf
+            cat << EOF > $PIP_CONFIG_FILE
+            [global]
+            timeout = 60
+            index-url = https://${RSPM_IP}/pypi/latest/simple
+            EOF
+            
             # Start Sessions
             /opt/R/3.6.3/bin/R --version
             /opt/R/3.6.3/bin/R --no-save -e "library(dplyr)"
@@ -397,6 +404,13 @@ Resources:
             sed -i -e 's|;\[RPackageRepository "CRAN"\]|\[RPackageRepository "CRAN"\]|' $CONNECT_CONFIG_FILE
             sed -i -e 's|;\[RPackageRepository "RSPM"\]|\[RPackageRepository "RSPM"\]|' $CONNECT_CONFIG_FILE
             sed -i -e "s|;URL = RSPM_SERVER_ADDRESS|URL = http://${RSPM_IP}/cran/__linux__/bionic/latest|" $CONNECT_CONFIG_FILE
+            
+            PIP_CONFIG_FILE=/etc/pip.conf
+            cat << EOF > $PIP_CONFIG_FILE
+            [global]
+            timeout = 60
+            index-url = https://${RSPM_IP}/pypi/latest/simple
+            EOF
 
             systemctl start rstudio-connect
 

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -299,7 +299,11 @@ Resources:
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             
             export DEBIAN_FRONTEND=noninteractive
-            apt install -y python-pip python-setuptools
+            
+            apt-get update -y
+            apt-get upgrade -y
+
+            apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
             python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             
@@ -414,7 +418,11 @@ Resources:
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             
             export DEBIAN_FRONTEND=noninteractive
-            apt install -y python-pip python-setuptools
+
+            apt-get update -y
+            apt-get upgrade -y
+
+            apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
             python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -309,7 +309,7 @@ Resources:
             cat << EOF > $PIP_CONFIG_FILE
             [global]
             timeout = 60
-            index-url = https://${RSPM_IP}/pypi/latest/simple
+            index-url = http://${RSPM_IP}/pypi/latest/simple
             EOF
             
             # Start Sessions
@@ -324,14 +324,14 @@ Resources:
             systemctl start rstudio-server
             systemctl start rstudio-launcher
 
-            /usr/local/bin/wait-for-it.sh localhost:80 -t 60
+            /usr/local/bin/wait-for-it.sh localhost:8787 -t 60
             rstudio-server stop
             sleep 10
             rstudio-server verify-installation --verify-user rstudio-user || true
             sleep 10
             rstudio-server start
 
-            /usr/local/bin/wait-for-it.sh localhost:80 -t 60
+            /usr/local/bin/wait-for-it.sh localhost:8787 -t 60
             /usr/local/bin/cfn-signal --exit-code 0 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}
 
           - RSC_IP: !GetAtt RSCInstance.PublicIp
@@ -396,11 +396,12 @@ Resources:
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             trap '/usr/local/bin/cfn-signal --exit-code 1 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
-            /usr/local/bin/wait-for-it.sh localhost:80 -t 60
-            sleep 5  # Wait for admin user creation
-            systemctl stop rstudio-connect
-
             CONNECT_CONFIG_FILE=/etc/rstudio-connect/rstudio-connect.gcfg
+
+            sed -i -e 's/Listen = \":3939\"/Listen = \":80\"/g' $CONNECT_CONFIG_FILE
+
+            systemctl restart rstudio-connect
+
             sed -i -e 's|;\[RPackageRepository "CRAN"\]|\[RPackageRepository "CRAN"\]|' $CONNECT_CONFIG_FILE
             sed -i -e 's|;\[RPackageRepository "RSPM"\]|\[RPackageRepository "RSPM"\]|' $CONNECT_CONFIG_FILE
             sed -i -e "s|;URL = RSPM_SERVER_ADDRESS|URL = http://${RSPM_IP}/cran/__linux__/bionic/latest|" $CONNECT_CONFIG_FILE
@@ -409,10 +410,10 @@ Resources:
             cat << EOF > $PIP_CONFIG_FILE
             [global]
             timeout = 60
-            index-url = https://${RSPM_IP}/pypi/latest/simple
+            index-url = http://${RSPM_IP}/pypi/latest/simple
             EOF
 
-            systemctl start rstudio-connect
+            systemctl restart rstudio-connect
 
             /usr/local/bin/wait-for-it.sh localhost:80 -t 60
             /usr/local/bin/cfn-signal --exit-code 0 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}
@@ -474,6 +475,12 @@ Resources:
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             trap '/usr/local/bin/cfn-signal --exit-code 1 --resource RSPMInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
+            
+            sed -i -e "s/Listen = :4242/Listen = :80/g" /etc/rstudio-pm/rstudio-pm.gcfg
+            setcap 'cap_net_bind_service=+ep' /opt/rstudio-pm/bin/rstudio-pm
+            sleep 10
+
+            systemctl restart rstudio-pm
 
             /usr/local/bin/wait-for-it.sh localhost:80 -t 60
             /usr/local/bin/cfn-signal --exit-code 0 --resource RSPMInstance --region ${AWS::Region} --stack ${AWS::StackName}

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -206,33 +206,33 @@ Mappings:
 
   RSCRegionMap:
     eu-central-1:
-      AMI: ami-094b7f5cae87907dd
+      AMI: ami-0fc53eb59f4b17110
     eu-north-1:
-      AMI: ami-0ea31068e99f8df91
+      AMI: ami-013ece7f61c627534
     eu-west-1:
-      AMI: ami-0e958dba717422144
+      AMI: ami-0023b14125e28c11a
     eu-west-2:
-      AMI: ami-00d7054d3d517802c
+      AMI: ami-0a46e8a8218a40a47
     eu-west-3:
-      AMI: ami-0355e9150a06de678
+      AMI: ami-0df7d98d66e84b834
     us-east-1:
       AMI: ami-0925289e48c7e041c
     us-east-2:
-      AMI: ami-0d654bde0b1fb03ae
+      AMI: ami-0a60db9be2f0c148b
     us-west-1:
-      AMI: ami-04ed4e5e4ce91002c
+      AMI: ami-0369e3b663d1b9032
     us-west-2:
-      AMI: ami-05aa2331ff635008d
+      AMI: ami-0a8a6e13f238b4bcd
     ap-northeast-1:
-      AMI: ami-0c72a69fd8f76bfbf
+      AMI: ami-02dac8221b546b333
     ap-northeast-2:
-      AMI: ami-04912a71571a0e3fd
+      AMI: ami-003570525ed0d4172
     ap-south-1:
-      AMI: ami-0b0e0f8a466687432
+      AMI: ami-05a5d804f3698a0ab
     ap-southeast-1:
-      AMI: ami-0eb2e999f192e0f3f
+      AMI: ami-00e116136c8ac5563
     ap-southeast-2:
-      AMI: ami-08f4772373c299cea
+      AMI: ami-0b46b11c2b1a84a27
 
   RSPMRegionMap:
     eu-central-1:

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -297,13 +297,22 @@ Resources:
           - |
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-            trap '/usr/local/bin/cfn-signal --exit-code 1 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
+            
+            export DEBIAN_FRONTEND=noninteractive
+            apt install -y python-pip python-setuptools
+            mkdir -p /opt/aws/bin
+            python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+            
+            trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
             RSESSION_CONFIG_FILE=/etc/rstudio/rsession.conf
-            sed -i -e "s|#default-rsconnect-server=RSC_SERVER_ADDRESS|default-rsconnect-server=http://${RSC_IP}|" $RSESSION_CONFIG_FILE
+            echo "default-rsconnect-server=http://${RSC_IP}|" >> $RSESSION_CONFIG_FILE
 
             REPOS_CONFIG_FILE=/etc/rstudio/repos.conf
-            sed -i -e "s|#CRAN=RSPM_SERVER_ADDRESS|CRAN=http://${RSPM_IP}/cran/__linux__/bionic/latest|" $REPOS_CONFIG_FILE
+            echo "CRAN=http://${RSPM_IP}/cran/__linux__/bionic/latest|" >> $REPOS_CONFIG_FILE
+            
+            RSERVER_CONFIG_FILE=/etc/rstudio/rserver.conf 
+            echo "www-port=80" >> $RSERVER_CONFIG_FILE
 
             PIP_CONFIG_FILE=/etc/pip.conf
             cat << EOF > $PIP_CONFIG_FILE
@@ -315,24 +324,27 @@ Resources:
             # Start Sessions
             /opt/R/3.6.3/bin/R --version
             /opt/R/3.6.3/bin/R --no-save -e "library(dplyr)"
-            /opt/python/3.8.1/bin/python --version
-            /opt/python/3.8.1/bin/python -c "import pandas"
+            /opt/Python/3.8.9/bin/python3 --version
+            /opt/Python/3.8.9/bin/python3 -c "import math"
 
             # Verify
             systemctl enable rstudio-server
             systemctl enable rstudio-launcher
-            systemctl start rstudio-server
-            systemctl start rstudio-launcher
+            systemctl restart rstudio-server
+            systemctl restart rstudio-launcher
 
-            /usr/local/bin/wait-for-it.sh localhost:8787 -t 60
+            curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+            chmod +x /usr/local/bin/wait-for-it.sh
+
+            /usr/local/bin/wait-for-it.sh localhost:80 -t 60
             rstudio-server stop
             sleep 10
             rstudio-server verify-installation --verify-user rstudio-user || true
             sleep 10
-            rstudio-server start
+            rstudio-server restart
 
-            /usr/local/bin/wait-for-it.sh localhost:8787 -t 60
-            /usr/local/bin/cfn-signal --exit-code 0 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}
+            /usr/local/bin/wait-for-it.sh localhost:80 -t 60
+            /opt/aws/bin/cfn-signal --exit-code 0 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}
 
           - RSC_IP: !GetAtt RSCInstance.PublicIp
             RSPM_IP: !GetAtt RSPMInstance.PublicIp
@@ -394,13 +406,17 @@ Resources:
           - |
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-            trap '/usr/local/bin/cfn-signal --exit-code 1 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
+            
+            export DEBIAN_FRONTEND=noninteractive
+            apt install -y python-pip python-setuptools
+            mkdir -p /opt/aws/bin
+            python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+
+            trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
             CONNECT_CONFIG_FILE=/etc/rstudio-connect/rstudio-connect.gcfg
 
             sed -i -e 's/Listen = \":3939\"/Listen = \":80\"/g' $CONNECT_CONFIG_FILE
-
-            systemctl restart rstudio-connect
 
             sed -i -e 's|;\[RPackageRepository "CRAN"\]|\[RPackageRepository "CRAN"\]|' $CONNECT_CONFIG_FILE
             sed -i -e 's|;\[RPackageRepository "RSPM"\]|\[RPackageRepository "RSPM"\]|' $CONNECT_CONFIG_FILE
@@ -415,8 +431,11 @@ Resources:
 
             systemctl restart rstudio-connect
 
+            curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+            chmod +x /usr/local/bin/wait-for-it.sh
+
             /usr/local/bin/wait-for-it.sh localhost:80 -t 60
-            /usr/local/bin/cfn-signal --exit-code 0 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}
+            /opt/aws/bin/cfn-signal --exit-code 0 --resource RSCInstance --region ${AWS::Region} --stack ${AWS::StackName}
 
           - RSPM_IP: !GetAtt RSPMInstance.PublicIp
 

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -176,33 +176,33 @@ Metadata:
 Mappings:
   RSPRegionMap:
     ap-northeast-1:
-      AMI: ami-089dbb2aafe4507ad
+      AMI: ami-0400ffd16cda0e53d
     ap-northeast-2:
-      AMI: ami-0281606354e8e6768
+      AMI: ami-033544f197fd94050
     ap-south-1:
-      AMI: ami-0c1a7524f33545ce5
+      AMI: ami-02802dc9a582fcb0d
     ap-southeast-1:
-      AMI: ami-0bf8a29c62d5156e8
+      AMI: ami-013d74602f69399f0
     ap-southeast-2:
-      AMI: ami-06b0fade7edc313ad
+      AMI: ami-07e0c5d55d521645c
     eu-central-1:
-      AMI: ami-0e284982aeeadfa8e
+      AMI: ami-04a38162e3d74331a
     eu-north-1:
-      AMI: ami-0ba34fa2cb4e369b9
+      AMI: ami-0bece7227d8a82425
     eu-west-1:
-      AMI: ami-010bd93e570070ca0
+      AMI: ami-09114541f8e41efb8
     eu-west-2:
-      AMI: ami-02332278c2064b57c
+      AMI: ami-02bc9099865ca25bb
     eu-west-3:
-      AMI: ami-0790eaebd8188279e
+      AMI: ami-0bccdef5ee0449395
     us-east-1:
       AMI: ami-04bd6989dfa69be83
     us-east-2:
-      AMI: ami-0a0fcfe7249fac9f5
+      AMI: ami-0f04b1190df907fde
     us-west-1:
-      AMI: ami-0d604623cad21cbac
+      AMI: ami-06f711a4856dacbdb
     us-west-2:
-      AMI: ami-0afb3900b3e6fd59a
+      AMI: ami-02de5980f62e1277e
 
   RSCRegionMap:
     eu-central-1:


### PR DESCRIPTION
This PR updates the CloudFormation template to use the latest BYOL AMIs deployed on us-east-1. 

Changes made to user-data scripts:

- RSP: 
    - Install CloudFormation tools
    - Change port from 8787 to 80
    - Change testing package from pandas to math
    - Install wait-for-it.sh
- RSC:
    - Install CloudFormation tools
    - Change port from 3939 to 80
    - Install wait-for-it.sh
- RSPM:
    - Change port from 4242 to 80
    - Set network linux capability for the rstudio-pm executable