### PR TITLE
Update RSPM code init to be more like Connect and remove apt-get upgrade

### DIFF
--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -306,6 +306,7 @@ Resources:
             apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
             python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+
             trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource RSWInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
             RSESSION_CONFIG_FILE=/etc/rstudio/rsession.conf
@@ -313,8 +314,8 @@ Resources:
 
             REPOS_CONFIG_FILE=/etc/rstudio/repos.conf
             echo "CRAN=http://${RSPM_IP}/cran/__linux__/bionic/latest" >> $REPOS_CONFIG_FILE
-            
-            RSERVER_CONFIG_FILE=/etc/rstudio/rserver.conf 
+
+            RSERVER_CONFIG_FILE=/etc/rstudio/rserver.conf
             echo "www-port=80" >> $RSERVER_CONFIG_FILE
             sed -i -e 's/8787/80/g' $RSERVER_CONFIG_FILE
 
@@ -324,6 +325,7 @@ Resources:
             timeout = 60
             index-url = https://pypi.python.org/simple
             EOF
+
 
             # Start Sessions
             /opt/R/3.6.3/bin/R --version
@@ -340,7 +342,7 @@ Resources:
 
             systemctl stop rstudio-launcher
             systemctl start rstudio-launcher
-            
+
             # Create first user
             user_passwd=$(curl http://169.254.169.254/latest/meta-data/instance-id)
             sudo useradd -m -p $(openssl passwd -crypt $user_passwd) rstudio-user
@@ -440,7 +442,7 @@ Resources:
 
             echo "[RPackageRepository \"CRAN\"]" >> $CONNECT_CONFIG_FILE
             echo "URL = http://${RSPM_IP}/cran/__linux__/bionic/latest" >> $CONNECT_CONFIG_FILE
-            
+
             ip_addr=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
             sed -i -e "s/Address = http:\/\/example.com/Address = http:\/\/$ip_addr/g" $CONNECT_CONFIG_FILE
 
@@ -548,7 +550,7 @@ Resources:
             /opt/rstudio-pm/bin/rspm create repo --name=pypi --type=python --description='Access PyPI packages'
             /opt/rstudio-pm/bin/rspm subscribe --repo=pypi --source=pypi
             /opt/rstudio-pm/bin/rspm sync --type=pypi --no-wait
-            
+
             /usr/local/bin/wait-for-it.sh localhost:80 -t 60
             /usr/local/bin/cfn-signal --exit-code 0 --resource RSPMInstance --region ${AWS::Region} --stack ${AWS::StackName}
 

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -297,16 +297,16 @@ Resources:
           - |
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-            
+
             export DEBIAN_FRONTEND=noninteractive
-            
+
             apt-get update -y
             apt-get upgrade -y
 
             apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
             python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-            
+
             trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource RSPInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
             RSESSION_CONFIG_FILE=/etc/rstudio/rsession.conf
@@ -314,8 +314,8 @@ Resources:
 
             REPOS_CONFIG_FILE=/etc/rstudio/repos.conf
             echo "CRAN=http://${RSPM_IP}/cran/__linux__/bionic/latest|" >> $REPOS_CONFIG_FILE
-            
-            RSERVER_CONFIG_FILE=/etc/rstudio/rserver.conf 
+
+            RSERVER_CONFIG_FILE=/etc/rstudio/rserver.conf
             echo "www-port=80" >> $RSERVER_CONFIG_FILE
 
             PIP_CONFIG_FILE=/etc/pip.conf
@@ -324,7 +324,7 @@ Resources:
             timeout = 60
             index-url = http://${RSPM_IP}/pypi/latest/simple
             EOF
-            
+
             # Start Sessions
             /opt/R/3.6.3/bin/R --version
             /opt/R/3.6.3/bin/R --no-save -e "library(dplyr)"
@@ -336,12 +336,12 @@ Resources:
             systemctl enable rstudio-launcher
             systemctl restart rstudio-server
             systemctl restart rstudio-launcher
-            
+
             # Create first user
             user_passwd=$(curl http://169.254.169.254/latest/meta-data/instance-id)
             sudo useradd -p $(openssl passwd -crypt $user_passwd) rstudio-user
             unset user_passwd
-            
+
             # Download Wait for It
             curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
             chmod +x /usr/local/bin/wait-for-it.sh
@@ -416,7 +416,7 @@ Resources:
           - |
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-            
+
             export DEBIAN_FRONTEND=noninteractive
 
             apt-get update -y
@@ -435,7 +435,7 @@ Resources:
             sed -i -e 's|;\[RPackageRepository "CRAN"\]|\[RPackageRepository "CRAN"\]|' $CONNECT_CONFIG_FILE
             sed -i -e 's|;\[RPackageRepository "RSPM"\]|\[RPackageRepository "RSPM"\]|' $CONNECT_CONFIG_FILE
             sed -i -e "s|;URL = RSPM_SERVER_ADDRESS|URL = http://${RSPM_IP}/cran/__linux__/bionic/latest|" $CONNECT_CONFIG_FILE
-            
+
             PIP_CONFIG_FILE=/etc/pip.conf
             cat << EOF > $PIP_CONFIG_FILE
             [global]
@@ -507,8 +507,18 @@ Resources:
         Fn::Base64: !Sub |
             #!/bin/bash -xe
             exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update -y
+            apt-get upgrade -y
+
+            apt-get install -y python-pip python-setuptools
+            mkdir -p /opt/aws/bin
+            python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+
             trap '/usr/local/bin/cfn-signal --exit-code 1 --resource RSPMInstance --region ${AWS::Region} --stack ${AWS::StackName}' ERR
-            
+
             sed -i -e "s/Listen = :4242/Listen = :80/g" /etc/rstudio-pm/rstudio-pm.gcfg
             setcap 'cap_net_bind_service=+ep' /opt/rstudio-pm/bin/rstudio-pm
             sleep 10

--- a/aws/cloudformation/rstudio-standalone.yml
+++ b/aws/cloudformation/rstudio-standalone.yml
@@ -301,7 +301,6 @@ Resources:
             export DEBIAN_FRONTEND=noninteractive
 
             apt-get update -y
-            apt-get upgrade -y
 
             apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
@@ -428,7 +427,6 @@ Resources:
             export DEBIAN_FRONTEND=noninteractive
 
             apt-get update -y
-            apt-get upgrade -y
 
             apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin
@@ -521,7 +519,6 @@ Resources:
             export DEBIAN_FRONTEND=noninteractive
 
             apt-get update -y
-            apt-get upgrade -y
 
             apt-get install -y python-pip python-setuptools
             mkdir -p /opt/aws/bin


### PR DESCRIPTION
Copy the start of the init code from Connect into RSPM.  This makes sure the instance has its packages up to date and also makes sure the Cloudformation example is in here.  (The example change then allows our internal AMI packaging to remove this, given it's the only one that has this and it was causing problems.)

As an aside, as a future improvement here, I would suggest moving to using Python 3 for this install.  This may just involve changing to use Python 3 and changing cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz to cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz.  But I didn't try that myself.